### PR TITLE
Add basic DI / support for one-class-per-route structure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: php
+php:
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
+  - nightly
+
+install: composer install --dev
+script: vendor/phpunit/phpunit/phpunit -c phpunit.xml --coverage-clover build/logs/clover.xml

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,9 @@
     "type": "project",
     "require": {
         "silex/silex": "1.3",
-        "clearbooks/labs": "dev-master"
+        "clearbooks/labs": "dev-master",
+        "tomverran/di-container-mock": "*",
+        "php-di/php-di": "^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"
@@ -20,6 +22,10 @@
         {
             "type": "vcs",
             "url": "https://github.com/clearbooks/labs"
+        },
+        {
+            "type": "composer",
+            "url": "https://carefulcoder.co.uk/composer"
         }
     ],
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a3f726d94a25f4d7ca17a65aa7236023",
+    "hash": "6a438d37a2502afcb0181ca1f16fe4e6",
     "packages": [
         {
             "name": "clearbooks/labs",
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/clearbooks/labs.git",
-                "reference": "a98be207dceee2dc7e2fe664882960d48b6064c4"
+                "reference": "ab6fe76ae9388a9945d7797e5e11c96b263b6ca3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/clearbooks/labs/zipball/a98be207dceee2dc7e2fe664882960d48b6064c4",
-                "reference": "a98be207dceee2dc7e2fe664882960d48b6064c4",
+                "url": "https://api.github.com/repos/clearbooks/labs/zipball/ab6fe76ae9388a9945d7797e5e11c96b263b6ca3",
+                "reference": "ab6fe76ae9388a9945d7797e5e11c96b263b6ca3",
                 "shasum": ""
             },
             "require-dev": {
@@ -46,10 +46,176 @@
             ],
             "description": "Sensible releases",
             "support": {
-                "source": "https://github.com/clearbooks/labs/tree/LABS-15",
+                "source": "https://github.com/clearbooks/labs/tree/master",
                 "issues": "https://github.com/clearbooks/labs/issues"
             },
-            "time": "2015-08-05 15:14:00"
+            "time": "2015-08-10 14:56:57"
+        },
+        {
+            "name": "container-interop/container-interop",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/fc08354828f8fd3245f77a66b9e23a6bca48297e",
+                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Container\\": "src/Interop/Container/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+            "time": "2014-12-30 15:22:37"
+        },
+        {
+            "name": "php-di/invoker",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-DI/Invoker.git",
+                "reference": "7ea703c62dbb29d64763fa85258826034ce3c97d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-DI/Invoker/zipball/7ea703c62dbb29d64763fa85258826034ce3c97d",
+                "reference": "7ea703c62dbb29d64763fa85258826034ce3c97d",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "~1.1"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "phpunit/phpunit": "~4.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Invoker\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Generic and extensible callable invoker",
+            "homepage": "https://github.com/PHP-DI/Invoker",
+            "keywords": [
+                "callable",
+                "dependency",
+                "dependency-injection",
+                "injection",
+                "invoke",
+                "invoker"
+            ],
+            "time": "2015-04-24 10:18:34"
+        },
+        {
+            "name": "php-di/php-di",
+            "version": "5.0.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-DI/PHP-DI.git",
+                "reference": "927b36f37201a754ee86957de43d4784336803fe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-DI/PHP-DI/zipball/927b36f37201a754ee86957de43d4784336803fe",
+                "reference": "927b36f37201a754ee86957de43d4784336803fe",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "~1.0",
+                "php": ">=5.4.0",
+                "php-di/invoker": "~1.0",
+                "php-di/phpdoc-reader": "~2.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.2",
+                "doctrine/cache": "~1.0",
+                "mnapoli/phpunit-easymock": "~0.1.4",
+                "ocramius/proxy-manager": "~1.0",
+                "phpunit/phpunit": "~4.5"
+            },
+            "suggest": {
+                "doctrine/annotations": "Install it if you want to use annotations (version ~1.2)",
+                "doctrine/cache": "Install it if you want to use the cache (version ~1.0)",
+                "ocramius/proxy-manager": "Install it if you want to use lazy injection (version ~1.0)"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DI\\": "src/DI/"
+                },
+                "files": [
+                    "src/DI/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The dependency injection container for humans",
+            "homepage": "http://php-di.org/",
+            "keywords": [
+                "container",
+                "dependency injection",
+                "di"
+            ],
+            "time": "2015-06-04 11:55:24"
+        },
+        {
+            "name": "php-di/phpdoc-reader",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-DI/PhpDocReader.git",
+                "reference": "21dce5e29f640d655e7b4583ecfb7d166127a5da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-DI/PhpDocReader/zipball/21dce5e29f640d655e7b4583ecfb7d166127a5da",
+                "reference": "21dce5e29f640d655e7b4583ecfb7d166127a5da",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpDocReader\\": "src/PhpDocReader"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PhpDocReader parses @var and @param values in PHP docblocks (supports namespaced class names with the same resolution rules as PHP)",
+            "keywords": [
+                "phpdoc",
+                "reflection"
+            ],
+            "time": "2015-06-01 14:23:20"
         },
         {
             "name": "pimple/pimple",
@@ -541,6 +707,43 @@
                 "url"
             ],
             "time": "2015-08-05 15:58:16"
+        },
+        {
+            "name": "tomverran/di-container-mock",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:tomverran/di-container-mock.git",
+                "reference": "fa47a598391790a0b03d0853cb6f3c0ed5e4ef4b"
+            },
+            "require": {
+                "container-interop/container-interop": "~1.0",
+                "php": ">=5.5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "TomVerran\\": "src/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tom Verran",
+                    "homepage": "https://carefulcoder.co.uk",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A mock container-interop container",
+            "homepage": "https://carefulcoder.co.uk",
+            "keywords": [
+                "Container",
+                "DI",
+                "IoC"
+            ],
+            "time": "2015-02-08 19:57:27"
         }
     ],
     "packages-dev": [

--- a/config/mappings.php
+++ b/config/mappings.php
@@ -1,0 +1,8 @@
+<?php
+use Clearbooks\Labs\Release\Gateway\DummyReleaseGateway;
+use Clearbooks\Labs\Release\Gateway\ReleaseGateway;
+
+return [
+    ReleaseGateway::class => \DI\object( DummyReleaseGateway::class ),
+    DateTimeInterface::class => \DI\object( DateTime::class )
+];

--- a/http/index.php
+++ b/http/index.php
@@ -1,7 +1,15 @@
 <?php
 use Clearbooks\LabsApi\Release\GetRelease;
 require_once "../vendor/autoload.php";
-$app = new \Silex\Application();
 
-$app->get( 'release/list', GetRelease::class . '::execute' );
+$app = new \Silex\Application();
+$cb = new \DI\ContainerBuilder();
+$cb->useAutowiring( true );
+
+$cb->addDefinitions( '../config/mappings.php' );
+$app['resolver'] = $app->share(function () use ( $app, $cb ) {
+    return new \Clearbooks\LabsApi\Framework\ControllerResolver( $app, $cb->build() );
+});
+
+$app->get( 'release/list', GetRelease::class );
 $app->run();

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         bootstrap="vendor/autoload.php"
+         verbose="true">
+    <testsuite name="Clear Books Labs JSON Api">
+        <directory suffix="Test.php">tests</directory>
+    </testsuite>
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Framework/ControllerResolver.php
+++ b/src/Framework/ControllerResolver.php
@@ -1,0 +1,37 @@
+<?php
+namespace Clearbooks\LabsApi\Framework;
+use Interop\Container\ContainerInterface;
+use Silex\Application;
+
+/**
+ * Class ControllerResolver
+ */
+class ControllerResolver extends \Silex\ControllerResolver
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * @param Application $app
+     * @param ContainerInterface $container
+     */
+    public function __construct( Application $app, ContainerInterface $container )
+    {
+        parent::__construct( $app );
+        $this->container = $container;
+    }
+
+    /**
+     * @param string $controller
+     * @return mixed|void
+     */
+    protected function createController( $controller )
+    {
+        if ( !in_array( Endpoint::class, class_implements( $controller ) ) ) {
+            return false;
+        }
+        return [$this->container->get( $controller ), 'execute'];
+    }
+}

--- a/src/Framework/Endpoint.php
+++ b/src/Framework/Endpoint.php
@@ -1,0 +1,7 @@
+<?php
+namespace Clearbooks\LabsApi\Framework;
+
+interface Endpoint
+{
+    public function execute();
+}

--- a/src/Release/GetRelease.php
+++ b/src/Release/GetRelease.php
@@ -1,19 +1,13 @@
 <?php
 namespace CLearbooks\LabsApi\Release;
+use Clearbooks\LabsApi\Framework\Endpoint;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Silex\Application;
 
-class GetRelease
+class GetRelease implements Endpoint
 {
     public function execute()
     {
-        return new JsonResponse( [
-            [
-                'name' => 'A'
-            ],
-            [
-                'name' => 'B'
-            ]
-        ] );
+        return new JsonResponse( [] );
     }
 }

--- a/tests/Framework/ControllerResolverTest.php
+++ b/tests/Framework/ControllerResolverTest.php
@@ -1,0 +1,77 @@
+<?php
+namespace Clearbooks\LabsApi\Framework;
+use Silex\Application;
+use stdClass;
+use Symfony\Component\HttpFoundation\Request;
+use TomVerran\MockContainer;
+
+class ControllerResolverTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var MockContainer
+     */
+    private $mockContainer;
+
+    /**
+     * @var ControllerResolver
+     */
+    private $resolver;
+
+    /**
+     * @var Application
+     */
+    private $app;
+
+    /**
+     * Get a request for the given controller
+     * @param $controller
+     * @return Request
+     */
+    private function getRequestWithController( $controller )
+    {
+        $req = new Request();
+        $req->attributes->add( [ '_controller' => $controller ] );
+        return $req;
+    }
+
+    private function resolve( $controller )
+    {
+        $req = $this->getRequestWithController( $controller );
+        return $this->resolver->getController( $req );
+    }
+
+    /**
+     * Set up
+     */
+    public function setUp()
+    {
+        $this->app = new Application;
+        $this->mockContainer = new MockContainer( [ EndpointDummy::class => new EndpointDummy ] );
+        $this->resolver = new ControllerResolver( $this->app, $this->mockContainer );
+    }
+
+    /**
+     * @test
+     */
+    public function givenNullName_returnFalse()
+    {
+        $this->assertFalse( $this->resolve( null ) );
+    }
+
+    /**
+     * @test
+     * @expectedException \Exception
+     */
+    public function givenClassWhichIsNotAnEndpoint_throwException()
+    {
+        $this->assertFalse( $this->resolve( StdClass::class ) );
+    }
+
+    /**
+     * @test
+     */
+    public function givenClassWhichIsAnEndpoint_returnArrayOfObjectAndMethod()
+    {
+        $this->assertEquals([new EndpointDummy, 'execute'],  $this->resolve( EndpointDummy::class ) );
+    }
+}

--- a/tests/Framework/EndpointDummy.php
+++ b/tests/Framework/EndpointDummy.php
@@ -1,0 +1,10 @@
+<?php
+namespace Clearbooks\LabsApi\Framework;
+
+class EndpointDummy implements Endpoint
+{
+    public function execute()
+    {
+        // do nothing.
+    }
+}

--- a/tests/Release/GetReleaseTest.php
+++ b/tests/Release/GetReleaseTest.php
@@ -12,7 +12,7 @@ class GetReleaseTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->ctrl = new GetRelease( new GetPublicRelease( new DummyReleaseGateway, new DateTime ) );
+        $this->ctrl = new GetRelease;
     }
 
     private function get()

--- a/tests/Release/GetReleaseTest.php
+++ b/tests/Release/GetReleaseTest.php
@@ -1,0 +1,30 @@
+<?php
+use Clearbooks\Labs\Release\Gateway\DummyReleaseGateway;
+use Clearbooks\Labs\Release\GetPublicRelease;
+use Clearbooks\LabsApi\Release\GetRelease;
+
+class GetReleaseTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var GetRelease
+     */
+    private $ctrl;
+
+    public function setUp()
+    {
+        $this->ctrl = new GetRelease( new GetPublicRelease( new DummyReleaseGateway, new DateTime ) );
+    }
+
+    private function get()
+    {
+        return json_decode( $this->ctrl->execute()->getContent() );
+    }
+
+    /**
+     * @test
+     */
+    public function givenNoReleases_outputEmptyArray()
+    {
+        $this->assertEquals( [], $this->get() );
+    }
+}


### PR DESCRIPTION
So this adds a ControllerResolver which replaces the built in silex one, so that we can define controllers with class names only which get loaded by a Container-Interop compliant DI container
