### PR TITLE
Labs 7 and 8 set toggle status

### DIFF
--- a/config/mappings.mysql.php
+++ b/config/mappings.mysql.php
@@ -3,12 +3,18 @@ use Clearbooks\Labs\Release\Gateway\ReleaseGateway;
 use Clearbooks\Labs\Release\Gateway\ReleaseToggleCollection;
 use Clearbooks\Labs\Toggle\Gateway\UserToggleGateway;
 use Clearbooks\Labs\Toggle\Gateway\ActivatableToggleGateway;
+use Clearbooks\Labs\User\MockPermissionService;
+use Clearbooks\Labs\User\UseCase\PermissionService;
+use Clearbooks\Labs\User\UseCase\ToggleStatusModifier;
+use Clearbooks\Labs\User\ToggleStatusModifier as ToggleStatusModifierImplementation;
+use Clearbooks\Labs\User\UseCase\ToggleStatusModifierService;
 use Clearbooks\LabsMysql\Release\MysqlReleaseGateway;
 use Clearbooks\LabsMysql\Release\MysqlReleaseToggleCollectionGateway;
 use Clearbooks\LabsMysql\Toggle\MysqlUserToggleGateway;
 use Clearbooks\LabsMysql\Toggle\MysqlActivatableToggleGateway;
 use Clearbooks\Labs\Toggle\Gateway\GroupToggleGateway;
 use Clearbooks\LabsMysql\Toggle\MysqlGroupToggleGateway;
+use Clearbooks\LabsMysql\User\MysqlToggleStatusModifierService;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 
@@ -18,6 +24,9 @@ return [
     UserToggleGateway::class => \Di\object(MysqlUserToggleGateway::class),
     ActivatableToggleGateway::class => \DI\object (MysqlActivatableToggleGateway::class),
     GroupToggleGateway::class => \Di\object(MysqlGroupToggleGateway::class),
+    ToggleStatusModifier::class => \Di\object(ToggleStatusModifierImplementation::class),
+    ToggleStatusModifierService::class => \Di\object(MysqlToggleStatusModifierService::class),
+    PermissionService::class => \Di\object(MockPermissionService::class),
 
     Connection::class => function() {
         return DriverManager::getConnection([

--- a/http/api/index.php
+++ b/http/api/index.php
@@ -4,6 +4,7 @@ use Clearbooks\LabsApi\Toggle\GetIsToggleActive;
 use Clearbooks\LabsApi\Toggle\GetGroupTogglesForRelease;
 use Clearbooks\LabsApi\Toggle\GetTogglesForRelease;
 use Clearbooks\LabsApi\Toggle\GetUserTogglesForRelease;
+use Clearbooks\LabsApi\User\UserToggleStatusModifier;
 
 /**
  * Swagger api information
@@ -139,5 +140,7 @@ $app->get( 'toggle/user/list', GetUserTogglesForRelease::class);
  * )
  */
 $app->get( 'toggle/group/list', GetGroupTogglesForRelease::class);
+
+$app->post('toggle/change-status', UserToggleStatusModifier::class);
 
 $app->run();

--- a/src/Framework/Endpoint.php
+++ b/src/Framework/Endpoint.php
@@ -4,5 +4,5 @@ use Symfony\Component\HttpFoundation\Request;
 
 interface Endpoint
 {
-    public function execute( Request $r );
+    public function execute( Request $request );
 }

--- a/src/Release/GetAllPublicReleases.php
+++ b/src/Release/GetAllPublicReleases.php
@@ -30,7 +30,7 @@ class GetAllPublicReleases implements Endpoint
 
     }
 
-    public function execute(Request $r)
+    public function execute(Request $request)
     {
         $releases = $this->getReleases->execute();
         $json = [];

--- a/src/User/UserToggleStatusModifier.php
+++ b/src/User/UserToggleStatusModifier.php
@@ -49,17 +49,13 @@ class UserToggleStatusModifier implements Endpoint
         }
 
         $groupId = $request->get('groupId');
-
         $labsRequest = $this->createLabsRequest($request, $groupId);
-
         $this->statusModifier->execute($labsRequest, $this->toggleStatusModifierResponseHandler);
-
         $response = $this->toggleStatusModifierResponseHandler->getLastHandledResponse();
 
         if(!empty($response->getErrors())) {
             return new JsonResponse("An error occurred", 400);
         }
-
         return new JsonResponse([true]);
     }
 

--- a/src/User/UserToggleStatusModifier.php
+++ b/src/User/UserToggleStatusModifier.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dan
+ * Date: 27/08/15
+ * Time: 12:15
+ */
+
+namespace Clearbooks\LabsApi\User;
+
+
+use Clearbooks\Labs\User\ToggleStatusModifier\Request as ModifyToggleRequest;
+use Clearbooks\Labs\User\ToggleStatusModifierResponseHandlerSpy;
+use Clearbooks\Labs\User\UseCase\ToggleStatusModifier;
+use Clearbooks\LabsApi\Framework\Endpoint;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class UserToggleStatusModifier implements Endpoint
+{
+    /**
+     * @var UserToggleStatusModifier
+     */
+    private $statusModifier;
+    /**
+     * @var ToggleStatusModifierResponseHandlerSpy
+     */
+    private $toggleStatusModifierResponseHandler;
+
+    /**
+     * ToggleStatusModifier constructor.
+     * @param ToggleStatusModifier $toggleStatusModifier
+     * @param ToggleStatusModifierResponseHandlerSpy $toggleStatusModifierResponseHandler
+     */
+    public function __construct(ToggleStatusModifier $toggleStatusModifier, ToggleStatusModifierResponseHandlerSpy $toggleStatusModifierResponseHandler)
+    {
+        $this->statusModifier = $toggleStatusModifier;
+        $this->toggleStatusModifierResponseHandler = $toggleStatusModifierResponseHandler;
+    }
+
+    /**
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function execute(Request $request)
+    {
+        if($this->requestIsNotValid($request)) {
+            return new JsonResponse("You didn't include all the necessary information", 400);
+        }
+
+        $groupId = $request->get('groupId');
+
+        $labsRequest = $this->createLabsRequest($request, $groupId);
+
+        $this->statusModifier->execute($labsRequest, $this->toggleStatusModifierResponseHandler);
+
+        $response = $this->toggleStatusModifierResponseHandler->getLastHandledResponse();
+
+        if(!empty($response->getErrors())) {
+            return new JsonResponse("An error occurred", 400);
+        }
+
+        return new JsonResponse([true]);
+    }
+
+    /**
+     * @param Request $request
+     * @param null|string $groupId
+     * @return ModifyToggleRequest
+     */
+    private function createLabsRequest(Request $request, $groupId = null)
+    {
+        return new ModifyToggleRequest($request->get('toggleId'), $request->get('newStatus'), $request->get('userId'), $groupId);
+    }
+
+    /**
+     * @param Request $request
+     * @return bool
+     */
+    private function requestIsNotValid(Request $request)
+    {
+        $toggleId = $request->get('toggleId');
+        $newStatus = $request->get('newStatus');
+        $userId = $request->get('userId');
+
+        return(!isset($toggleId) || !isset($newStatus) || !isset($userId));
+    }
+}

--- a/tests/EndpointTest.php
+++ b/tests/EndpointTest.php
@@ -32,4 +32,9 @@ abstract class EndpointTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals( $expected, json_decode( $this->response->getContent(), true ) );
     }
+
+    protected function assert400()
+    {
+        $this->assertEquals(400, $this->response->getStatusCode());
+    }
 }

--- a/tests/Framework/EndpointDummy.php
+++ b/tests/Framework/EndpointDummy.php
@@ -4,6 +4,9 @@ use Symfony\Component\HttpFoundation\Request;
 
 class EndpointDummy implements Endpoint
 {
+    /**
+     * @param Request $request
+     */
     public function execute( Request $request )
     {
         // do nothing.

--- a/tests/Framework/EndpointDummy.php
+++ b/tests/Framework/EndpointDummy.php
@@ -4,7 +4,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class EndpointDummy implements Endpoint
 {
-    public function execute( Request $r )
+    public function execute( Request $request )
     {
         // do nothing.
     }

--- a/tests/Toggle/GetGroupTogglesForReleaseTest.php
+++ b/tests/Toggle/GetGroupTogglesForReleaseTest.php
@@ -46,7 +46,7 @@ class GetGroupTogglesForReleaseTest extends EndpointTest
     public function givenNoReleaseID_return400()
     {
         $this->executeWithQuery([]);
-        $this->assertEquals(400, $this->response->getStatusCode());
+        $this->assert400();
     }
 
     /**

--- a/tests/Toggle/GetIsToggleActiveTest.php
+++ b/tests/Toggle/GetIsToggleActiveTest.php
@@ -38,7 +38,7 @@ class GetIsToggleActiveTest extends EndpointTest
     public function givenNoToggleName_return400()
     {
         $this->executeWithQuery([]);
-        $this->assertEquals(400, $this->response->getStatusCode());
+        $this->assert400();
     }
 
     /**

--- a/tests/Toggle/GetTogglesTest.php
+++ b/tests/Toggle/GetTogglesTest.php
@@ -29,7 +29,7 @@ class GetTogglesTest extends EndpointTest
     public function givenNoRelease_return400()
     {
         $this->executeWithQuery( [] );
-        $this->assertEquals( 400, $this->response->getStatusCode() );
+        $this->assert400();
     }
 
     /**

--- a/tests/Toggle/GetUserTogglesForReleaseTest.php
+++ b/tests/Toggle/GetUserTogglesForReleaseTest.php
@@ -44,7 +44,7 @@ class GetUserTogglesForReleaseTest extends EndpointTest
     public function givenNoReleaseId_return400()
     {
         $this->executeWithQuery([]);
-        $this->assertEquals(400, $this->response->getStatusCode());
+        $this->assert400();
     }
 
     /**

--- a/tests/User/UserToggleStatusModifierTest.php
+++ b/tests/User/UserToggleStatusModifierTest.php
@@ -40,7 +40,7 @@ class UserToggleStatusModifierTest extends EndpointTest
      */
     public function givenNoToggleId_WhenTogglingStatus_Return400()
     {
-        $this->executeWithQuery(['newStatus' => ToggleStatusModifier::TOGGLE_STATUS_ACTIVE, 'userId' => '1']);
+        $this->executeWithQuery(['newStatus' => "active", 'userId' => '1']);
         $this->assert400();
 
     }
@@ -59,7 +59,7 @@ class UserToggleStatusModifierTest extends EndpointTest
      */
     public function givenNoUserId_WhenTogglingStatus_Return400()
     {
-        $this->executeWithQuery(['toggleId' => '1', 'newStatus' => ToggleStatusModifier::TOGGLE_STATUS_ACTIVE]);
+        $this->executeWithQuery(['toggleId' => '1', 'newStatus' => "active"]);
         $this->assert400();
     }
 
@@ -84,7 +84,7 @@ class UserToggleStatusModifierTest extends EndpointTest
         $this->executeWithQuery(
             [
                 'toggleId' => '1',
-                'newStatus' => ToggleStatusModifier::TOGGLE_STATUS_ACTIVE,
+                'newStatus' => "active",
                 'userId' => '1'
             ]
         );

--- a/tests/User/UserToggleStatusModifierTest.php
+++ b/tests/User/UserToggleStatusModifierTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dan
+ * Date: 27/08/15
+ * Time: 12:18
+ */
+
+namespace User;
+
+
+use Clearbooks\Labs\User\MockPermissionService;
+use Clearbooks\Labs\User\SuccessfulToggleStatusModifierServiceSpy;
+use Clearbooks\Labs\User\ToggleStatusModifier;
+use Clearbooks\Labs\User\ToggleStatusModifierRequestValidator;
+use Clearbooks\Labs\User\ToggleStatusModifierResponseHandlerSpy;
+use Clearbooks\LabsApi\EndpointTest;
+use Clearbooks\LabsApi\User\UserToggleStatusModifier;
+
+class UserToggleStatusModifierTest extends EndpointTest
+{
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->endpoint = new UserToggleStatusModifier(
+            new ToggleStatusModifier(
+                new SuccessfulToggleStatusModifierServiceSpy(),
+                new ToggleStatusModifierRequestValidator(
+                    new MockPermissionService()
+                )
+            ),
+            new ToggleStatusModifierResponseHandlerSpy()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function givenNoToggleId_WhenTogglingStatus_Return400()
+    {
+        $this->executeWithQuery(['newStatus' => ToggleStatusModifier::TOGGLE_STATUS_ACTIVE, 'userId' => '1']);
+        $this->assert400();
+
+    }
+
+    /**
+     * @test
+     */
+    public function givenNoNewStatus_WhenTogglingStatus_Return400()
+    {
+        $this->executeWithQuery(['toggleId' => '1', 'userId' => '1']);
+        $this->assert400();
+    }
+
+    /**
+     * @test
+     */
+    public function givenNoUserId_WhenTogglingStatus_Return400()
+    {
+        $this->executeWithQuery(['toggleId' => '1', 'newStatus' => ToggleStatusModifier::TOGGLE_STATUS_ACTIVE]);
+        $this->assert400();
+    }
+
+    /**
+     * @test
+     */
+    public function givenToggleThatWillError_WhenTogglingStatus_Return400()
+    {
+        $this->executeWithQuery([
+            'toggleId' => '1',
+            'newStatus' => 'asdf',
+            'userId' => '1'
+        ]);
+        $this->assert400();
+    }
+
+    /**
+     * @test
+     */
+    public function givenCorrectToggleInfo_WhenTogglingStatus_CorrectlyToggleStatus()
+    {
+        $this->executeWithQuery(
+            [
+                'toggleId' => '1',
+                'newStatus' => ToggleStatusModifier::TOGGLE_STATUS_ACTIVE,
+                'userId' => '1'
+            ]
+        );
+
+        $this->assertJsonResponse([true]);
+    }
+}

--- a/tests/User/UserToggleStatusModifierTest.php
+++ b/tests/User/UserToggleStatusModifierTest.php
@@ -42,7 +42,6 @@ class UserToggleStatusModifierTest extends EndpointTest
     {
         $this->executeWithQuery(['newStatus' => "active", 'userId' => '1']);
         $this->assert400();
-
     }
 
     /**
@@ -88,7 +87,6 @@ class UserToggleStatusModifierTest extends EndpointTest
                 'userId' => '1'
             ]
         );
-
         $this->assertJsonResponse([true]);
     }
 }


### PR DESCRIPTION
Sooooo I'm not sure if I should be using `ToggleStatusModifierResponseHandlerSpy` but it was the only `ToggleStatusModifyResponseHandler` where I could get the last request
