### PR TITLE
add endpoint for getting all future visible releases

### DIFF
--- a/http/api/index.php
+++ b/http/api/index.php
@@ -2,6 +2,7 @@
 use Clearbooks\Dilex\JwtGuard;
 use Clearbooks\LabsApi\Group\GroupToggleStatusModifier;
 use Clearbooks\LabsApi\Feedback\AddFeedbackForToggle;
+use Clearbooks\LabsApi\Release\GetAllFutureVisibleReleases;
 use Clearbooks\LabsApi\Release\GetAllPublicReleases;
 use Clearbooks\LabsApi\Toggle\GetGroupTogglesForRelease;
 use Clearbooks\LabsApi\Toggle\GetTogglesActivatedByUser;
@@ -54,6 +55,8 @@ $app->before( JwtGuard::class );
  * )
  */
 $app->get( 'public-releases/list', GetAllPublicReleases::class );
+
+$app->get( 'future-visible-releases/list', GetAllFutureVisibleReleases::class);
 
 /**
  * @SWG\Get(

--- a/src/Release/GetAllFutureVisibleReleases.php
+++ b/src/Release/GetAllFutureVisibleReleases.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dan
+ * Date: 28/12/15
+ * Time: 13:28
+ */
+
+namespace Clearbooks\LabsApi\Release;
+
+
+use Clearbooks\Dilex\Endpoint;
+use Clearbooks\Labs\Release\Gateway\ReleaseGateway;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class GetAllFutureVisibleReleases implements Endpoint
+{
+    /**
+     * @var ReleaseGateway
+     */
+    private $gateway;
+
+
+    /**
+     * GetAllFutureVisibleReleases constructor.
+     * @param ReleaseGateway $gateway
+     */
+    public function __construct(ReleaseGateway $gateway)
+    {
+        $this->gateway = $gateway;
+    }
+
+    public function execute(Request $request)
+    {
+        $releases = $this->gateway->getAllFutureVisibleReleases();
+        $json = [];
+
+        foreach ($releases as $release) {
+            $json[] =
+                [
+                    'id' => $release->getReleaseId(),
+                    'date' => $release->getReleaseDate()->format('Y-m-d')
+                ];
+        }
+        return new JsonResponse($json);
+
+    }
+}

--- a/tests/Release/GetAllFutureVisibleReleasesTest.php
+++ b/tests/Release/GetAllFutureVisibleReleasesTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dan
+ * Date: 28/12/15
+ * Time: 13:29
+ */
+
+namespace Clearbooks\LabsApi\Release;
+
+
+use Clearbooks\Labs\Release\Gateway\MockReleaseGateway;
+use Clearbooks\Labs\Release\Release;
+use Clearbooks\LabsApi\EndpointTest;
+
+class GetAllFutureVisibleReleasesTest extends EndpointTest
+{
+    private $releases;
+
+    const RELEASE_ID = "1";
+
+    const RELEASE_NAME = "name";
+
+    const RELEASE_URL = "url";
+
+    const RELEASE_DATE = "2015-01-01";
+
+    const RELEASE_VISIBLE = true;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->releases = [new Release(
+            self::RELEASE_ID, self::RELEASE_NAME, self::RELEASE_URL,
+            new \DateTime(self::RELEASE_DATE), self::RELEASE_VISIBLE
+        )];
+
+        $this->endpoint = new GetAllFutureVisibleReleases(
+            new MockReleaseGateway($this->releases)
+        );
+    }
+
+
+    /**
+     * @test
+     */
+    public function givenReleases_whenGettingAllFutureVisibleReleases_returnArrayOfReleases()
+    {
+        $this->executeWithQuery([]);
+
+        $this->assertJsonResponse(
+            [[
+                'id' => self::RELEASE_ID,
+                'date' => self::RELEASE_DATE
+            ]]
+        );
+    }
+
+
+}


### PR DESCRIPTION
requires these two to be merged beforehand:

https://github.com/clearbooks/labs/pull/50
https://github.com/clearbooks/labs-mysql/pull/37

*\* copied from my clearbooks/labs#50 *\* 
I was bored and wanted to do some php

Adds a method for getting all future, and visible releases, this will probably be useful if the decision ever comes to have future releases visible for longer (i.e. we have something we want people to try out for longer)
